### PR TITLE
Support commands with arguments

### DIFF
--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -61,9 +61,25 @@ class TestWrite(unittest.TestCase):
 
         self.assertEqual(actual_contents, expected_contents)
 
+    def test_shows_error_message_for_no_arguments(self):
+        stderr = subprocess.run(['lldb', self.binary_path, '--batch', '-o', 'command script import write.py', '-o',
+                       'write'],
+                       check=True,
+                       capture_output=True).stderr.decode('utf-8')
 
+        expected_error_message = "too few arguments"
+        self.assertIn(expected_error_message, stderr)
 
+    def test_shows_error_message_for_one_argument(self):
+        output_file = self.working_dir_path / 'parsing.txt'
+        stderr = subprocess.run(['lldb', self.binary_path, '--batch', '-o', 'command script import write.py', '-o',
+                       f'write {output_file}'],
+                       check=True,
+                       capture_output=True).stderr.decode('utf-8')
 
+        expected_error_message = "too few arguments"
+        self.assertIn(expected_error_message, stderr)
+        self.assertFalse(output_file.exists())  # Nothing should be written to the file if the script wasn't called correctly!
 
 
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -48,6 +48,19 @@ class TestWrite(unittest.TestCase):
 
         self.assertEqual(actual_contents, expected_contents)
 
+    def test_handles_commands_with_arguments(self):
+        output_file = self.working_dir_path / 'arguments.txt'
+        subprocess.run(['lldb', self.binary_path, '--batch', '-o', 'command script import write.py', '-o',
+                        f'write {output_file} platform shell echo --this-is-an-argument'],
+                       check=True)
+
+        expected_contents = '''(lldb) platform shell echo --this-is-an-argument\n\n--this-is-an-argument\n'''
+
+        with open(output_file, 'r') as f:
+            actual_contents = f.read()
+
+        self.assertEqual(actual_contents, expected_contents)
+
 
 
 

--- a/write.py
+++ b/write.py
@@ -6,6 +6,10 @@ import argparse
 def parse_args(raw_args):
     """Parse the arguments given to write"""
     args = raw_args.split(' ')
+
+    if len(args) < 2:
+        raise ValueError('write: too few arguments\nusage: write filename command [command ...]')
+
     filename = args[0]
     command = ' '.join(args[1:])
 


### PR DESCRIPTION
argparse was gobbling up any arguments starting with '-' or '--', which broke support for lldb commands that use arguments (e.g. image lookup --address $ADDRESS)

Fixed by removing argparse and using a simpler argument handling method

Also adds simple error handling to deal with incorrect arguments
